### PR TITLE
Make deployment sdist contain proto generated files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ deploy:
   password:
     # secure token: `echo -n "password" | travis encrypt --add deploy.password -r wangkuiyi/pysqlflow`
     secure: sDAa83Ty6gY5VEcGX8vZcy6poyHod2TUnZ9XQ/Bc8n9o5Zm1b7om6tvo8rJ5AyokDcWmXCTj8wqP4wcajnvzRee25dOfjZync23h+lrO23ovH7omSwmbjzaDIQa8OjlUz9AckI7GcW8h1Q9ARmr4vSBrGmk6qj0OADVNcsRRa7899ICArqI3PAfLj8zgu6Z2fvAcyzUi/Fmal4kOn/gjiB6Kpid2AxuWysyGe/lqxdIYfPmWCOKko68pkwcI+NJZoIZaK+C4Ahpv3SvKlvPBS9/JxTsKXy7zKbBrLQfqSGHRX06sciHtDD9BxY0kQmh0CezvZvl+inqodoTL6gS7QfEt4pdagKb2vYvJrDNdyZNJSyuI357oTMGpS4bOCfxl5iQY73MttZXnC8OqmMJAWOcMhwMIayKjJJPALkCVyi5bHeqORepMIAx4QvAb/N1IObe+ltUCkmofSqxk0g26V6xcVB/ECfdjwPWY0h76MhCC+VkncuGImRcGaUQ4j/tnKDN2wDnst4WFs9xZf4Jq55gQyz+6loxU3Nhj3TzOpl8vFC92ozqfz4THjiymxstJfff0UidGQrP6rmWFTJFf5TePFdqVwkEVTs/tasetVP9aFL4ixR89A1uHQEL/n3Eby6AyD6ODIP0qTIkLadPe8yNrT9Qvg2FFRPOAbMmQyDk=
-  distributions: sdist
+  distributions: sdist bdist_wheel
   skip_existing: true
   skip_cleanup: true
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ script:
 - make protoc
 - python setup.py -q test
 
-before_deploy:
-- make protoc
-- find sqlflow # print all files
-
 deploy:
   provider: pypi
   user: tonyyang

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ script:
 
 before_deploy:
 - make protoc
+- find sqlflow # print all files
 
 deploy:
   provider: pypi
@@ -33,6 +34,7 @@ deploy:
     secure: sDAa83Ty6gY5VEcGX8vZcy6poyHod2TUnZ9XQ/Bc8n9o5Zm1b7om6tvo8rJ5AyokDcWmXCTj8wqP4wcajnvzRee25dOfjZync23h+lrO23ovH7omSwmbjzaDIQa8OjlUz9AckI7GcW8h1Q9ARmr4vSBrGmk6qj0OADVNcsRRa7899ICArqI3PAfLj8zgu6Z2fvAcyzUi/Fmal4kOn/gjiB6Kpid2AxuWysyGe/lqxdIYfPmWCOKko68pkwcI+NJZoIZaK+C4Ahpv3SvKlvPBS9/JxTsKXy7zKbBrLQfqSGHRX06sciHtDD9BxY0kQmh0CezvZvl+inqodoTL6gS7QfEt4pdagKb2vYvJrDNdyZNJSyuI357oTMGpS4bOCfxl5iQY73MttZXnC8OqmMJAWOcMhwMIayKjJJPALkCVyi5bHeqORepMIAx4QvAb/N1IObe+ltUCkmofSqxk0g26V6xcVB/ECfdjwPWY0h76MhCC+VkncuGImRcGaUQ4j/tnKDN2wDnst4WFs9xZf4Jq55gQyz+6loxU3Nhj3TzOpl8vFC92ozqfz4THjiymxstJfff0UidGQrP6rmWFTJFf5TePFdqVwkEVTs/tasetVP9aFL4ixR89A1uHQEL/n3Eby6AyD6ODIP0qTIkLadPe8yNrT9Qvg2FFRPOAbMmQyDk=
   distributions: sdist
   skip_existing: true
+  skip_cleanup: true
   on:
     tags: true
     repo: wangkuiyi/pysqlflow

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ deploy:
   password:
     # secure token: `echo -n "password" | travis encrypt --add deploy.password -r wangkuiyi/pysqlflow`
     secure: sDAa83Ty6gY5VEcGX8vZcy6poyHod2TUnZ9XQ/Bc8n9o5Zm1b7om6tvo8rJ5AyokDcWmXCTj8wqP4wcajnvzRee25dOfjZync23h+lrO23ovH7omSwmbjzaDIQa8OjlUz9AckI7GcW8h1Q9ARmr4vSBrGmk6qj0OADVNcsRRa7899ICArqI3PAfLj8zgu6Z2fvAcyzUi/Fmal4kOn/gjiB6Kpid2AxuWysyGe/lqxdIYfPmWCOKko68pkwcI+NJZoIZaK+C4Ahpv3SvKlvPBS9/JxTsKXy7zKbBrLQfqSGHRX06sciHtDD9BxY0kQmh0CezvZvl+inqodoTL6gS7QfEt4pdagKb2vYvJrDNdyZNJSyuI357oTMGpS4bOCfxl5iQY73MttZXnC8OqmMJAWOcMhwMIayKjJJPALkCVyi5bHeqORepMIAx4QvAb/N1IObe+ltUCkmofSqxk0g26V6xcVB/ECfdjwPWY0h76MhCC+VkncuGImRcGaUQ4j/tnKDN2wDnst4WFs9xZf4Jq55gQyz+6loxU3Nhj3TzOpl8vFC92ozqfz4THjiymxstJfff0UidGQrP6rmWFTJFf5TePFdqVwkEVTs/tasetVP9aFL4ixR89A1uHQEL/n3Eby6AyD6ODIP0qTIkLadPe8yNrT9Qvg2FFRPOAbMmQyDk=
-  distributions: sdist bdist_wheel
+  distributions: sdist
   skip_existing: true
   on:
     tags: true

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ protoc: ## Generate python client from proto file
 	&& pip install grpcio-tools \
 	&& mkdir -p build/grpc/sqlflow/proto \
 	&& python -m grpc_tools.protoc -Iproto --python_out=. \
-		--grpc_python_out=. proto/sqlflow/proto/sqlflow.proto
+		--grpc_python_out=. proto/sqlflow/proto/sqlflow.proto \
+	&& touch sqlflow/proto/__init__.py
 
 release: ## Release new version
 	$(if $(shell git status -s), $(error "Please commit your changes or stash them before you release."))

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ protoc: ## Generate python client from proto file
 	&& pip install grpcio-tools \
 	&& mkdir -p build/grpc/sqlflow/proto \
 	&& python -m grpc_tools.protoc -Iproto --python_out=. \
-		--grpc_python_out=. proto/sqlflow/proto/sqlflow.proto \
-	&& touch sqlflow/proto/__init__.py
+		--grpc_python_out=. proto/sqlflow/proto/sqlflow.proto
 
 release: ## Release new version
 	$(if $(shell git status -s), $(error "Please commit your changes or stash them before you release."))


### PR DESCRIPTION
I have been hacking around the travis CI for hours and ended up using `skip_cleanup` flag, under which the deployment contains proto generated python file. https://travis-ci.org/wangkuiyi/pysqlflow/jobs/500175875#L349

Methods I have tried but didn't work out:
1. disable `bdist_wheel `
1. `touch sqlflow/proto/__init__.py` to make `setup.py` think `sqlflow.proto` is a package

